### PR TITLE
ci: tag releases automatically

### DIFF
--- a/.github/workflows/cd_buildAndPublish.yml
+++ b/.github/workflows/cd_buildAndPublish.yml
@@ -8,7 +8,7 @@ on:
         # branches:
         #    - main
         tags:
-            - '*.*.*'
+            - 'v*.*.*'
 
 env:
     DOCKER_VENDOR: ${{ vars.DOCKER_HUB_USERNAME }}

--- a/.github/workflows/cd_tagReleases.yml
+++ b/.github/workflows/cd_tagReleases.yml
@@ -1,0 +1,20 @@
+name: CD - Tag Releases
+
+on:
+    workflow_dispatch:
+    push:
+        branches:
+            - main
+
+jobs:
+    tag-release:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v5
+            - name: Install monorepo
+              uses: ./.github/actions/install-monorepo
+              with:
+                branch: ${{ github.event.base_ref }}
+            - name: Tag Release
+              run: |
+                pnpm nx release --skip-publish


### PR DESCRIPTION
Generate releases automatically on commit to `main`