### PR TITLE
ci: skip tag release if last commit was publish commit

### DIFF
--- a/.github/workflows/cd_tagReleases.yml
+++ b/.github/workflows/cd_tagReleases.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
     tag-release:
+        if: ${{ !startsWith(github.event.head_commit.message, 'chore(release)') }}
         runs-on: ubuntu-latest
         permissions:
           contents: write


### PR DESCRIPTION
We don't want to re-run tag releases again right after it finished